### PR TITLE
Add docker stats formatter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-feeder
-======
+feedr
+=====
 
 |Build Status|
 
@@ -9,7 +9,9 @@ feeder
 
 |PypI|
 
-feeder generates events/logs using a specified formatter and sends them
+|Documentation Status|
+
+feedr generates events/logs using a specified formatter and sends them
 using the specified transport. It can also generate fake data using
 fake-factory.
 
@@ -17,29 +19,29 @@ Quick Start
 ~~~~~~~~~~~
 
 `Quick
-Start <http://feeder.readthedocs.org/en/latest/quick_start.html>`__
+Start <http://feedr.readthedocs.org/en/latest/quick_start.html>`__
 
 Documentation
 ~~~~~~~~~~~~~
 
-`feeder Documentation <http://feeder.readthedocs.org>`__
+`feedr Documentation <http://feedr.readthedocs.org>`__
 
 Installation
 ~~~~~~~~~~~~
 
 .. code:: shell
 
-     pip install feeder
+     pip install feedr
      # or, for dev:
-     pip install https://github.com/nir0s/feeder/archive/master.tar.gz
+     pip install https://github.com/nir0s/feedr/archive/master.tar.gz
 
 Usage Examples
 ~~~~~~~~~~~~~~
 
-see `feeder
-config <http://feeder.readthedocs.org/en/latest/configuration.html>`__
+see `feedr
+config <http://feedr.readthedocs.org/en/latest/configuration.html>`__
 and `advanced
-config <http://feeder.readthedocs.org/en/latest/advanced_configuration.html>`__
+config <http://feedr.readthedocs.org/en/latest/advanced_configuration.html>`__
 to configure your transports and formatters.
 
 .. code:: shell
@@ -63,27 +65,28 @@ to configure your transports and formatters.
 Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~
 
--  `Use
-   Case <http://feeder.readthedocs.org/en/latest/case_study.html>`__
--  `Configuration <http://feeder.readthedocs.org/en/latest/configuration.html>`__
--  `formatters <http://feeder.readthedocs.org/en/latest/formatters.html>`__
--  `transports <http://feeder.readthedocs.org/en/latest/transports.html>`__
--  `API <http://feeder.readthedocs.org/en/latest/api.html>`__
--  `InHouseFaker <http://feeder.readthedocs.org/en/latest/in_house_faker.html>`__
+-  `Use Case <http://feedr.readthedocs.org/en/latest/case_study.html>`__
+-  `Configuration <http://feedr.readthedocs.org/en/latest/configuration.html>`__
+-  `formatters <http://feedr.readthedocs.org/en/latest/formatters.html>`__
+-  `transports <http://feedr.readthedocs.org/en/latest/transports.html>`__
+-  `API <http://feedr.readthedocs.org/en/latest/api.html>`__
+-  `InHouseFaker <http://feedr.readthedocs.org/en/latest/in_house_faker.html>`__
 
 Vagrant
 ~~~~~~~
 
-A vagrantfile is provided: It will load a machine and install feeder on
+A vagrantfile is provided: It will load a machine and install feedr on
 it in a virtualenv so that you can experiment with it. For a machine
-containing feeder, ELK and RabbitMQ see the `elk-workshop
+containing feedr, ELK and RabbitMQ see the `elk-workshop
 repo <https://github.com/nir0s/elk-workshop>`__.
 
-.. |Build Status| image:: https://travis-ci.org/nir0s/feeder.svg?branch=master
-   :target: https://travis-ci.org/nir0s/feeder
-.. |Gitter chat| image:: https://badges.gitter.im/nir0s/feeder.png
-   :target: https://gitter.im/nir0s/feeder
-.. |PyPI| image:: http://img.shields.io/pypi/dm/feeder.svg
-   :target: http://img.shields.io/pypi/dm/feeder.svg
-.. |PypI| image:: http://img.shields.io/pypi/v/feeder.svg
-   :target: http://img.shields.io/pypi/v/feeder.svg
+.. |Build Status| image:: https://travis-ci.org/nir0s/feedr.svg?branch=master
+   :target: https://travis-ci.org/nir0s/feedr
+.. |Gitter chat| image:: https://badges.gitter.im/nir0s/feedr.png
+   :target: https://gitter.im/nir0s/feedr
+.. |PyPI| image:: http://img.shields.io/pypi/dm/feedr.svg
+   :target: http://img.shields.io/pypi/dm/feedr.svg
+.. |PypI| image:: http://img.shields.io/pypi/v/feedr.svg
+   :target: http://img.shields.io/pypi/v/feedr.svg
+.. |Documentation Status| image:: https://readthedocs.org/projects/feedr/badge/?version=latest
+   :target: https://readthedocs.org/projects/feedr/?badge=latest

--- a/docs/formatter_docker_stats.rst
+++ b/docs/formatter_docker_stats.rst
@@ -1,0 +1,29 @@
+==========================
+The Docker Stats Formatter
+==========================
+
+Allows Generating Docker Stats for a specific container.
+
+.. note:: Stats are enabled only for Docker API v1.17 and above!
+
+Configuration Example
+---------------------
+
+.. code-block:: python
+
+ 'MyDockerStatsFormatter': {
+     'container': 'elasticsearch'  # the container to read stats from
+     'client_config': {  # The Docker API client config.
+        'version': '1.17',
+        ...
+     }
+ },
+
+.. note:: The Docker API client config can be found `here <http://docker-py.readthedocs.org/en/latest/api/#client-api>`_.
+
+Example Output
+--------------
+
+.. code-block:: bash
+
+ {"read":"2015-02-12T18:57:15.567808366+02:00","network":{"rx_bytes":1038195,"rx_packets":7050,"rx_errors":0,"rx_dropped":0,"tx_by tes":1176,"tx_packets":13,"tx_errors":0,"tx_dropped":0},"cpu_stats":{"cpu_usage":{"total_usage":265217625353,"percpu_usage":[8814 0506837,41897336235,88440908322,46738873959],"usage_in_kernelmode":64780000000,"usage_in_usermode":99160000000},"system_cpu_usage ":346652980000000,"throttling_data":{"periods":0,"throttled_periods":0,"throttled_time":0}},"memory_stats":{"usage":87769088,"max _usage":258166784,"stats":{"active_anon":43143168,"active_file":2564096,"cache":3723264,"hierarchical_memory_limit":1844674407370 9551615,"inactive_anon":40988672,"inactive_file":1159168,"mapped_file":2945024,"pgfault":141225,"pgmajfault":3455,"pgpgin":146589 ,"pgpgout":130271,"rss":84045824,"rss_huge":10485760,"total_active_anon":43143168,"total_active_file":2564096,"total_cache":37232 64,"total_inactive_anon":40988672,"total_inactive_file":1159168,"total_mapped_file":2945024,"total_pgfault":141225,"total_pgmajfa ult":3455,"total_pgpgin":146589,"total_pgpgout":130271,"total_rss":84045824,"total_rss_huge":10485760,"total_unevictable":0,"tota l_writeback":0,"unevictable":0,"writeback":0},"failcnt":0,"limit":8039038976},"blkio_stats":{"io_service_bytes_recursive":[{"majo r":8,"minor":0,"op":"Read","value":141418496},{"major":8,"minor":0,"op":"Write","value":4096},{"major":8,"minor":0,"op":"Sync","v alue":4096},{"major":8,"minor":0,"op":"Async","value":141418496},{"major":8,"minor":0,"op":"Total","value":141422592}],"io_servic ed_recursive":[{"major":8,"minor":0,"op":"Read","value":26770},{"major":8,"minor":0,"op":"Write","value":1},{"major":8,"minor":0, "op":"Sync","value":1},{"major":8,"minor":0,"op":"Async","value":26770},{"major":8,"minor":0,"op":"Total","value":26771}],"io_que ue_recursive":[],"io_service_time_recursive":[],"io_wait_time_recursive":[],"io_merged_recursive":[],"io_time_recursive":[],"sect ors_recursive":[]}}

--- a/docs/formatters.rst
+++ b/docs/formatters.rst
@@ -26,6 +26,7 @@ Contents:
    formatter_apache_access
    formatter_apache_access_ex
    formatter_apache_error
+   formatter_docker_stats
 
 .. automodule:: feedr.formatters
    :members:

--- a/feedr/__init__.py
+++ b/feedr/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ['feedr']
 __author__ = 'nir0s'
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/feedr/formatters.py
+++ b/feedr/formatters.py
@@ -8,6 +8,7 @@ from faker import Factory
 from format_mappings import InHouseFaker
 import json
 import uuid
+import docker
 
 
 DEFAULT_CUSTOM_FORMAT = [
@@ -309,3 +310,20 @@ class ApacheErrorFormatter(CustomFormatter):
             'catch_phrase': self.f(config, 'catch_phrase'),
             'syslog_error_levels_lower': self.f(config, 'syslog_error_levels_lower'),  # NOQA
         }
+
+
+class DockerStatsFormatter():
+    """returns stats from a docker container"""
+    def __init__(self, config):
+        try:
+            self.container = config['container']
+        except KeyError as ex:
+            raise RuntimeError('configuration incomplete: {0}'.format(ex))
+        self.client_config = config.get('client_config')
+
+    def generate_data(self):
+        client = docker.Client(**self.client_config) \
+            if self.client_config else docker.Client()
+        stream = client.stats(self.container)
+        for stat in stream:
+            return stat

--- a/feedr/tests/resources/mock_config.py
+++ b/feedr/tests/resources/mock_config.py
@@ -74,6 +74,10 @@ GENERATOR = {
                 'NON_EXISTENT_DATA_FOR_RAND': '$RAND'
             }
         },
+        'MyDockerStatsFormatter': {
+            'type': 'DockerStats',
+            'container': 'elasticsearch'
+        }
     },
     'transports': {
         'MyAmqpTransport': {

--- a/feedr/tests/test_feedr.py
+++ b/feedr/tests/test_feedr.py
@@ -13,8 +13,6 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-__author__ = 'nir0s'
-
 from feedr.feedr import FeedrError
 import feedr.logger as logger
 import feedr.feedr as fd

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 # from setuptools import find_packages
-from setuptools.command.test import test as TestCommand
+from setuptools.command.test import test as testcommand
 import sys
 import re
 import os
@@ -24,14 +24,14 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-class Tox(TestCommand):
+class Tox(testcommand):
     def finalize_options(self):
-        TestCommand.finalize_options(self)
+        testcommand.finalize_options(self)
         self.test_args = []
         self.test_suite = True
 
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
+        # import here, cause outside the eggs aren't loaded
         import tox
         errcode = tox.cmdline(self.test_args)
         sys.exit(errcode)
@@ -63,6 +63,7 @@ setup(
         "LogentriesLogger==0.2.1",
         "pymongo==2.7.1",
         "influxdb==0.1.12",
+        "docker-py==0.7.3",
     ],
     tests_require=['nose', 'tox'],
     cmdclass={'test': Tox},


### PR DESCRIPTION
This depends on the future docker-py 0.7.3 release supporting API version 1.17 which adds the `stats` API.

This will be pending the release of the new version.
